### PR TITLE
Add Configuration to Include CRM Metadata in Query Builder Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ npm install @doralhw-org/coql-query-builder
 
 ## Usage
 
-You'll need to create a object of the query builder and pass it a function that can fetch the data with the provided query.
-This function must return the data in the same format as the Zoho CRM API response.
+You'll need to create a object of the query builder and pass it a function that can fetch the data with the provided query. This function must return the data in the same format as the Zoho CRM API response.
 
 ```ts
 import { CoqlQueryBuilder } from "@doralhw-org/coql-query-builder";
@@ -25,8 +24,7 @@ const coqlQueryBuilder = new CoqlQueryBuilder({
 
 ### Fetching data
 
-After creating the query builder object you can use the `select` method to fetch the data. The query passed will then be turned
-to one or more COQL queries and executed. The data will then be merged together and returned as an array of records.
+After creating the query builder object you can use the `select` method to fetch the data. The query passed will then be turned to one or more COQL queries and executed. The data will then be merged together and returned as an array of records.
 
 ```ts
 const records = await coqlQueryBuilder.select({
@@ -43,11 +41,9 @@ const records = await coqlQueryBuilder.select({
 });
 ```
 
-This merge is performed based on the `id` column. If the `id` column is not added as a column to the query, it will be added
-to the queries generated. If the `id` column has a different name, or you want to group based on a different identifier
-column, you may alias the column to `id` .
+This merge is performed based on the `id` column. If the `id` column is not added as a column to the query, it will be added to the queries generated. If the `id` column has a different name, or you want to group based on a different identifier column, you may alias the column to `id` .
 
-Alternatively, you can use the static `buildQuery` method to build the query and then execute it on your own. The method will return one or more COQL queries depending on the workarounds required to obtain the data based on the limitations of the Zoho CRM API.
+Alternatively, you can use the `buildQuery` method to build the query and then execute it on your own. The method will return one or more COQL queries depending on the workarounds required to obtain the data based on the limitations of the Zoho CRM API.
 
 ```ts
 const queries = coqlQueryBuilder.buildQuery({

--- a/lib/coql-query-builder.spec.ts
+++ b/lib/coql-query-builder.spec.ts
@@ -1,0 +1,201 @@
+import { CoqlQueryBuilder } from "./coql-query-builder";
+import { queryBuilder } from "./query-builder";
+
+jest.mock("./query-builder");
+
+describe("COQL Query Builder Class", () => {
+  const mockQueryBuilder = jest.mocked(queryBuilder);
+  const mockQueryFunction = jest.fn().mockResolvedValue({
+    data: [],
+    info: {
+      count: 0,
+      more_records: false,
+    },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockQueryBuilder.mockReturnValue(["select id, First_Name from users"]);
+  });
+
+  it("should return a basic select query with no metadata", async () => {
+    const builder = new CoqlQueryBuilder({
+      queryFunction: mockQueryFunction,
+    });
+
+    const records = await builder.select({
+      columns: ["id", "First_Name"],
+      from: "users",
+    });
+
+    expect(records).toEqual([]);
+  });
+
+  it("should deduplicate records", async () => {
+    mockQueryFunction.mockResolvedValueOnce({
+      data: [{ id: "1", First_Name: "John", Email: "john@example.com" }],
+      info: {
+        count: 1,
+        more_records: false,
+      },
+    });
+    mockQueryFunction.mockResolvedValueOnce({
+      data: [{ id: "1", Mobile: "1234567890" }],
+      info: {
+        count: 1,
+        more_records: false,
+      },
+    });
+
+    mockQueryBuilder.mockReturnValue([
+      "select id, First_Name, Email from users",
+      "select id, Mobile from users",
+    ]);
+
+    const builder = new CoqlQueryBuilder({
+      queryFunction: mockQueryFunction,
+    });
+
+    // Mocking workaround when we exceed 50 columns selected
+    const records = await builder.select({
+      columns: ["id", "First_Name", "Email", "Mobile"],
+      from: "users",
+    });
+
+    expect(records).toEqual([
+      {
+        id: "1",
+        First_Name: "John",
+        Email: "john@example.com",
+        Mobile: "1234567890",
+      },
+    ]);
+  });
+
+  it("should return a basic select query with metadata", async () => {
+    const builder = new CoqlQueryBuilder({
+      queryFunction: mockQueryFunction,
+    });
+
+    const records = await builder.select(
+      {
+        columns: ["id", "First_Name"],
+        from: "users",
+      },
+      {
+        includeMetadata: true,
+      }
+    );
+
+    expect(records).toEqual({
+      data: [],
+      info: {
+        count: 0,
+        more_records: false,
+      },
+    });
+  });
+
+  it("should deduplicate records with metadata", async () => {
+    mockQueryFunction.mockResolvedValueOnce({
+      data: [
+        { id: "1", First_Name: "John", Email: "john@example.com" },
+        { id: "2", First_Name: "Bessy", Email: "bessy@example.com" },
+      ],
+      info: {
+        count: 1,
+        more_records: false,
+      },
+    });
+    mockQueryFunction.mockResolvedValueOnce({
+      data: [
+        { id: "1", Mobile: "1234567890" },
+        { id: "2", Mobile: "1234567890" },
+      ],
+      info: {
+        count: 1,
+        more_records: false,
+      },
+    });
+
+    mockQueryBuilder.mockReturnValue([
+      "select id, First_Name, Email from users",
+      "select id, Mobile from users",
+    ]);
+
+    const builder = new CoqlQueryBuilder({
+      queryFunction: mockQueryFunction,
+    });
+
+    // Mocking workaround when we exceed 50 columns selected
+    const records = await builder.select(
+      {
+        columns: ["id", "First_Name", "Email", "Mobile"],
+        from: "users",
+      },
+      {
+        includeMetadata: true,
+      }
+    );
+
+    expect(records).toEqual({
+      data: [
+        {
+          id: "1",
+          First_Name: "John",
+          Email: "john@example.com",
+          Mobile: "1234567890",
+        },
+        {
+          id: "2",
+          First_Name: "Bessy",
+          Email: "bessy@example.com",
+          Mobile: "1234567890",
+        },
+      ],
+      info: {
+        count: 2,
+        more_records: false,
+      },
+    });
+  });
+
+  it("should return built single query from query builder", () => {
+    const builder = new CoqlQueryBuilder({
+      queryFunction: mockQueryFunction,
+    });
+
+    const queries = builder.buildQuery({
+      columns: ["id", "First_Name"],
+      from: "users",
+    });
+
+    expect(queries).toEqual(["select id, First_Name from users"]);
+  });
+
+  it("should return built multiple queries from query builder", () => {
+    const mockQueries = [
+      "select id, First_Name from users",
+      "select id, First_Name from users where (First_Name = 'John')",
+    ];
+
+    mockQueryBuilder.mockReturnValue(mockQueries);
+
+    const builder = new CoqlQueryBuilder({
+      queryFunction: mockQueryFunction,
+    });
+
+    const queries = builder.buildQuery({
+      columns: ["id", "First_Name"],
+      from: "users",
+      where: [
+        {
+          equals: [{ column: "First_Name" }, { value: "John" }],
+        },
+      ],
+    });
+
+    expect(queries).toEqual(mockQueries);
+  });
+});

--- a/lib/types/crm.ts
+++ b/lib/types/crm.ts
@@ -5,10 +5,12 @@ export type CrmCoqlRecord = {
 
 export type CrmCoqlResponse<RecordType = CrmCoqlRecord> = {
   data: RecordType[];
-  info: {
-    count: number;
-    more_records: boolean;
-  };
+  info: CrmCoqlQueryMetadata;
+};
+
+export type CrmCoqlQueryMetadata = {
+  count: number;
+  more_records: boolean;
 };
 
 /**

--- a/lib/types/query.ts
+++ b/lib/types/query.ts
@@ -68,4 +68,11 @@ export type QueryBuilderConfiguration = {
    * @default "none"
    */
   automaticColumnAliasing?: "none" | "camelCase";
+  /**
+   * Adds metadata coming from Zoho to the query. Turning it from an array of records to an object with a "data" and "info" property.
+   * If deduplication occurs, the more_records property will be true if any of the responses has more_records set to true.
+   *
+   * @default false
+   */
+  includeMetadata?: boolean;
 };


### PR DESCRIPTION
**Changelog**
- Added `includeMetadata` option to include metadata information that comes from Zoho.
- Added test suite for the COQL query builder class.
- Fixed outdated documentation in root directory README file.