### PR TITLE
Add Safeguards Against Empty String Responses from CRM API

### DIFF
--- a/lib/types/crm.ts
+++ b/lib/types/crm.ts
@@ -16,8 +16,8 @@ export type CrmCoqlQueryMetadata = {
 /**
  * This is the function type that must be provided to the CoqlQueryBuilder constructor.
  *
- * It must receive directly a COQL query string and return a CrmCoqlResponse object.
+ * It must receive directly a COQL query string and return zoho's response.
  */
 export type CrmCoqlQueryFunction = <RecordType = CrmCoqlRecord>(
   coqlQuery: string
-) => Promise<CrmCoqlResponse<RecordType>>;
+) => Promise<CrmCoqlResponse<RecordType> | "">;


### PR DESCRIPTION
**Changelog**
- Added safeguards against empty string responses from the API.
- Added tests to cover empty string response cases